### PR TITLE
first pisi releases of two python bindings

### DIFF
--- a/programming/language/python/python-sphinxcontrib-websupport/actions.py
+++ b/programming/language/python/python-sphinxcontrib-websupport/actions.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import pythonmodules
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import shelltools
+from pisi.actionsapi import get
+
+WorkDir="sphinxcontrib-websupport-%s" % get.srcVERSION()
+
+def setup():
+    shelltools.cd("..")
+    shelltools.makedirs("build_python3")
+    shelltools.copytree("./%s" % WorkDir,  "build_python3")
+    shelltools.cd(WorkDir)
+
+def build():
+    pythonmodules.compile()
+
+    shelltools.cd("../build_python3/%s" % WorkDir)
+    pythonmodules.compile(pyVer="3")
+
+def install():
+    pythonmodules.install("-O1")
+    
+    shelltools.cd("../build_python3/%s" % WorkDir)
+    pythonmodules.install("-O1", pyVer="3")
+
+    for dirs in ["tests"]:
+        pisitools.insinto("%s/%s" % (get.docDIR(), get.srcNAME()), dirs)

--- a/programming/language/python/python-sphinxcontrib-websupport/pspec.xml
+++ b/programming/language/python/python-sphinxcontrib-websupport/pspec.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "http://www.pisilinux.org/projeler/pisi/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>python-sphinxcontrib-websupport</Name>
+        <Homepage>https://www.sphinx-doc.org/</Homepage>
+        <Packager>
+            <Name>Blue Devil</Name>
+            <Email>bluedevil@sctzine.com</Email>
+        </Packager>
+        <License>BSD</License>
+        <IsA>library</IsA>
+        <Summary>Sphinx API for Web Apps</Summary>
+        <Description>python-sphinxcontrib-websupport is the Sphinx documentation generator.</Description>
+        <Archive sha1sum="5675e157af122cfab6abd4b14f80cb360b6c307a" type="targz">https://pypi.org/packages/source/s/sphinxcontrib-websupport/sphinxcontrib-websupport-1.1.2.tar.gz</Archive>
+        <BuildDependencies>
+            <Dependency>python3-setuptools</Dependency>
+            <Dependency>python-setuptools</Dependency>
+            <Dependency>python3-devel</Dependency>
+            <Dependency>python-devel</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>python-sphinxcontrib-websupport</Name>
+        <Summary>sphinxcontrib-websupport module for python</Summary>
+        <Files>
+            <Path fileType="library">/usr/lib</Path>
+            <Path fileType="doc">/usr/share/doc/python-sphinxcontrib-websupport</Path>
+        </Files>
+    </Package>
+    
+    <Package>
+        <Name>python3-sphinxcontrib-websupport</Name>
+        <Summary>sphinxcontrib-websupport module for python3</Summary>
+        <Files>
+            <Path fileType="library">/usr/lib/python3*</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2019-11-13</Date>
+            <Version>1.1.2</Version>
+            <Comment>First pisi release</Comment>
+            <Name>Blue Devil</Name>
+            <Email>bluedevil@sctzine.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/programming/language/python/python-sphinxcontrib-websupport/translations.xml
+++ b/programming/language/python/python-sphinxcontrib-websupport/translations.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<PISI>
+    <Source>
+        <Name>python-sphinxcontrib-websupport</Name>
+        <Summary xml:lang="tr">Yazılımlarınız ve sunucularınız için bir parola hashi üreten python modülüdür.</Summary>
+        <Description xml:lang="tr">python-sphinxcontrib-websupport, Sphinx belhelendirme üretecisidir.</Description>
+    </Source>
+    
+    <Package>
+        <Name>python3-sphinxcontrib-websupport</Name>
+        <Summary xml:lang="tr">Yazılımlarınız ve sunucularınız için bir parola hashi üreten python modülüdür.</Summary>
+        <Description xml:lang="tr">python-sphinxcontrib-websupport, Sphinx belhelendirme üretecisidir.</Description>
+    </Package>
+</PISI>

--- a/programming/language/python/python-typing/actions.py
+++ b/programming/language/python/python-typing/actions.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the GNU General Public License, version 3.
+# See the file http://www.gnu.org/licenses/gpl.txt
+
+from pisi.actionsapi import pythonmodules
+from pisi.actionsapi import pisitools
+from pisi.actionsapi import shelltools
+from pisi.actionsapi import get
+
+WorkDir="typing-%s" % get.srcVERSION()
+
+def build():
+    pythonmodules.compile()
+
+def install():
+    pythonmodules.install()
+    pisitools.dodoc("README*","LICENSE*")
+

--- a/programming/language/python/python-typing/pspec.xml
+++ b/programming/language/python/python-typing/pspec.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM 'http://www.pisilinux.org/projeler/pisi/pisi-spec.dtd'>
+<PISI>
+    <Source>
+        <Name>python-typing</Name>
+        <Homepage>https://pypi.org/project/typing/</Homepage>
+        <Packager>
+            <Name>Blue Devil</Name>
+            <Email>bluedevil@sctzine.com</Email>
+        </Packager>
+        <License>PSF</License>
+        <IsA>library</IsA>
+        <Summary>Backport of the standard library typing module</Summary>
+        <Description>This is a backport of the standard library typing module to Python versions older than 3.5. Typing defines a standard notation for Python function and variable type annotations. The notation can be used for documenting code in a concise, standard format, and it has been designed to also be used by static and runtime type checkers, static analyzers, IDEs and other tools.</Description>
+        <Archive sha1sum="f977239c310a5dd5ae5b6cb598d76eba45b92ed6" type="targz">https://pypi.io/packages/source/t/typing/typing-3.7.4.1.tar.gz</Archive>
+        <BuildDependencies>
+            <Dependency>python-setuptools</Dependency>
+            <Dependency>python-devel</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>python-typing</Name>
+        <Files>
+            <Path fileType="library">/usr/lib</Path>
+            <Path fileType="doc">/usr/share/doc/python-typing</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>2019-11-13</Date>
+            <Version>3.7.4.1</Version>
+            <Comment>First Pisi Release</Comment>
+            <Name>Blue Devil</Name>
+            <Email>bluedevil@sctzine.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/programming/language/python/python-typing/translations.xml
+++ b/programming/language/python/python-typing/translations.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<PISI>
+    <Source>
+        <Name>python-typing</Name>
+        <Summary xml:lang="tr">Geriye dönük Python 2.7 typing bağlayıcıları</Summary>
+        <Description xml:lang="tr">Python 3.5'dan önceki sürümler için geriye dönüklük destegi saglayan pyton2 bağlayıcısıdır.</Description>
+    </Source>
+</PISI>


### PR DESCRIPTION
typing binding is default after py3.5
this package is a backport support for the versions before py3.5